### PR TITLE
Scrub temp paths.

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -51,3 +51,13 @@ scrub_config <- function(input) {
 scrub_tempdir <- function(input) {
   sub("^.*Rtmp\\S+", "TMPDIR", input)
 }
+
+scrub_path <- function(input, keep_dirs = c("R", "tests")) {
+  dirs_string <- paste0(keep_dirs, collapse = "|")
+  search <- glue("^.*(/({dirs_string})/)")
+  stringr::str_replace(
+    input,
+    search,
+    "\\1"
+  )
+}

--- a/tests/testthat/test-generate_pkg_main.R
+++ b/tests/testthat/test-generate_pkg_main.R
@@ -8,15 +8,13 @@ test_that("generate_pkg() returns a vector of created files", {
   saveRDS(guru_rapid, "guru_rapid.rds")
 
   test_result <- generate_pkg(pkg_agent = "TESTPKG (https://example.com)")
-  expected_result <- paste0(
-    test_dir,
-    c(
-      "/R/010-call.R",
-      "/tests/testthat/test-010-call.R",
-      "/R/paths-apis.R",
-      "/tests/testthat/test-paths-apis.R",
-      "/tests/testthat/setup.R"
-    )
+  test_result <- scrub_path(test_result)
+  expected_result <- c(
+    "/R/010-call.R",
+    "/tests/testthat/test-010-call.R",
+    "/R/paths-apis.R",
+    "/tests/testthat/test-paths-apis.R",
+    "/tests/testthat/setup.R"
   )
 
   expect_identical(test_result, expected_result)


### PR DESCRIPTION
GHA workflow runners had some confusion in test results.