### PR TITLE
Strip ansi characters from tibblify specs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ BugReports: https://github.com/api2r/beekeeper/issues
 Depends:
     R (>= 4.1.0)
 Imports:
+    cli,
     dplyr,
     fs,
     glue,

--- a/R/generate_pkg_paths.R
+++ b/R/generate_pkg_paths.R
@@ -278,12 +278,12 @@ S7::method(as_bk_data, class_paths) <- function(x, ...) {
     return(list(tidy_policy_body = tidy_policy_body, description = description))
   }
 
-  indented_spec <- format(
+  indented_spec <- cli::ansi_strip(format(
     spec,
     width = 78,
     fully_qualify = TRUE,
     nchar_indent = 2
-  )
+  ))
   tidy_policy_body <- paste0(
     "spec <- ",
     indented_spec,


### PR DESCRIPTION
Don't include color codes (etc) when packages are generated in a terminal that supports colors.

Closes #118