### PR TITLE
Safer `.to_snake()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -131,10 +131,10 @@ if (exists("%||%", envir = baseenv())) {
 #' @keywords internal
 .to_snake <- function(x) {
   x |>
-    stringr::str_replace_all("([a-z])([A-Z])", "\\1_\\2") |>
-    stringr::str_replace_all("([a-zA-Z])([0-9])", "\\1_\\2") |>
-    stringr::str_replace_all("([0-9])([a-zA-Z])", "\\1_\\2") |>
-    stringr::str_replace_all("[^a-zA-Z0-9]+", "_") |>
+    stringr::str_replace_all("(\\p{Ll})(\\p{Lu})", "\\1_\\2") |>
+    stringr::str_replace_all("(\\p{L})(\\p{Nd})", "\\1_\\2") |>
+    stringr::str_replace_all("(\\p{Nd})(\\p{L})", "\\1_\\2") |>
+    stringr::str_replace_all("[^\\p{L}\\p{Nd}]+", "_") |>
     stringr::str_replace_all("^_+|_+$", "") |>
     stringr::str_replace_all("_+", "_") |>
     tolower()

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -56,6 +56,13 @@ test_that(".glue_pipe_brace() works (#noissue)", {
 
 test_that(".to_snake() works (#noissue)", {
   expect_identical(.to_snake("camelCase"), "camel_case")
+  expect_identical(.to_snake("caféBar"), "café_bar")
+  expect_identical(.to_snake("version2"), "version_2")
+  expect_identical(.to_snake("2fast"), "2_fast")
+  expect_identical(.to_snake("foo-bar"), "foo_bar")
+  expect_identical(.to_snake("-foo-"), "foo")
+  expect_identical(.to_snake("foo__bar"), "foo_bar")
+  expect_identical(.to_snake("FOO"), "foo")
   expect_identical(.to_snake("APIs"), "apis")
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -56,6 +56,7 @@ test_that(".glue_pipe_brace() works (#noissue)", {
 
 test_that(".to_snake() works (#noissue)", {
   expect_identical(.to_snake("camelCase"), "camel_case")
+  expect_identical(.to_snake("APIs"), "apis")
 })
 
 test_that(".flatten_df() returns data frame unchanged (#noissue)", {


### PR DESCRIPTION
Use unicode properties to find lowercase letters, uppercase letters, any letter, and any digit, rather than patterns like `[a-z]`. Also ensure that all cases work as expected via more robust tests.