### PR TITLE
Namespace httptest2 in generated path tests

### DIFF
--- a/inst/templates/test-paths.R
+++ b/inst/templates/test-paths.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/{{tag}}/{{fn_prefix}}{{operation_id}}", {
+httptest2::with_mock_dir("api/path/{{tag}}/{{fn_prefix}}{{operation_id}}", {
   test_that("{{fn_prefix}}{{operation_id}}() returns expected result", {
     beekeeper::skip_if_not_exported("{{fn_prefix}}{{operation_id}}")
     expect_snapshot({

--- a/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_audit_case.R
+++ b/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_audit_case.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/audit/get_audit_case", {
+httptest2::with_mock_dir("api/path/audit/get_audit_case", {
   test_that("get_audit_case() returns expected result", {
     beekeeper::skip_if_not_exported("get_audit_case")
     expect_snapshot({

--- a/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_audit_category.R
+++ b/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_audit_category.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/audit/get_audit_category", {
+httptest2::with_mock_dir("api/path/audit/get_audit_category", {
   test_that("get_audit_category() returns expected result", {
     beekeeper::skip_if_not_exported("get_audit_category")
     expect_snapshot({

--- a/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_audit_primary_category.R
+++ b/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_audit_primary_category.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/audit/get_audit_primary_category", {
+httptest2::with_mock_dir("api/path/audit/get_audit_primary_category", {
   test_that("get_audit_primary_category() returns expected result", {
     beekeeper::skip_if_not_exported("get_audit_primary_category")
     expect_snapshot({

--- a/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_names_audit_candidates.R
+++ b/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_names_audit_candidates.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/audit/get_names_audit_candidates", {
+httptest2::with_mock_dir("api/path/audit/get_names_audit_candidates", {
   test_that("get_names_audit_candidates() returns expected result", {
     beekeeper::skip_if_not_exported("get_names_audit_candidates")
     expect_snapshot({

--- a/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_names_audit_committees.R
+++ b/tests/testthat/_fixtures/fec/testthat/test-paths-audit-get_names_audit_committees.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/audit/get_names_audit_committees", {
+httptest2::with_mock_dir("api/path/audit/get_names_audit_committees", {
   test_that("get_names_audit_committees() returns expected result", {
     beekeeper::skip_if_not_exported("get_names_audit_committees")
     expect_snapshot({

--- a/tests/testthat/_fixtures/fec/testthat/test-paths-debts-get_schedules_schedule_d.R
+++ b/tests/testthat/_fixtures/fec/testthat/test-paths-debts-get_schedules_schedule_d.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/debts/get_schedules_schedule_d", {
+httptest2::with_mock_dir("api/path/debts/get_schedules_schedule_d", {
   test_that("get_schedules_schedule_d() returns expected result", {
     beekeeper::skip_if_not_exported("get_schedules_schedule_d")
     expect_snapshot({

--- a/tests/testthat/_fixtures/fec/testthat/test-paths-debts-get_schedules_schedule_d_sub_id.R
+++ b/tests/testthat/_fixtures/fec/testthat/test-paths-debts-get_schedules_schedule_d_sub_id.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/debts/get_schedules_schedule_d_sub_id", {
+httptest2::with_mock_dir("api/path/debts/get_schedules_schedule_d_sub_id", {
   test_that("get_schedules_schedule_d_sub_id() returns expected result", {
     beekeeper::skip_if_not_exported("get_schedules_schedule_d_sub_id")
     expect_snapshot({

--- a/tests/testthat/_fixtures/fec/testthat/test-paths-legal-get_legal_search.R
+++ b/tests/testthat/_fixtures/fec/testthat/test-paths-legal-get_legal_search.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/legal/get_legal_search", {
+httptest2::with_mock_dir("api/path/legal/get_legal_search", {
   test_that("get_legal_search() returns expected result", {
     beekeeper::skip_if_not_exported("get_legal_search")
     expect_snapshot({

--- a/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_api.R
+++ b/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_api.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/apis/get_api", {
+httptest2::with_mock_dir("api/path/apis/get_api", {
   test_that("get_api() returns expected result", {
     beekeeper::skip_if_not_exported("get_api")
     expect_snapshot({

--- a/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_metrics.R
+++ b/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_metrics.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/apis/get_metrics", {
+httptest2::with_mock_dir("api/path/apis/get_metrics", {
   test_that("get_metrics() returns expected result", {
     beekeeper::skip_if_not_exported("get_metrics")
     expect_snapshot({

--- a/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_provider.R
+++ b/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_provider.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/apis/get_provider", {
+httptest2::with_mock_dir("api/path/apis/get_provider", {
   test_that("get_provider() returns expected result", {
     beekeeper::skip_if_not_exported("get_provider")
     expect_snapshot({

--- a/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_providers.R
+++ b/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_providers.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/apis/get_providers", {
+httptest2::with_mock_dir("api/path/apis/get_providers", {
   test_that("get_providers() returns expected result", {
     beekeeper::skip_if_not_exported("get_providers")
     expect_snapshot({

--- a/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_service_api.R
+++ b/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_service_api.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/apis/get_service_api", {
+httptest2::with_mock_dir("api/path/apis/get_service_api", {
   test_that("get_service_api() returns expected result", {
     beekeeper::skip_if_not_exported("get_service_api")
     expect_snapshot({

--- a/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_services.R
+++ b/tests/testthat/_fixtures/guru/testthat/test-paths-apis-get_services.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/apis/get_services", {
+httptest2::with_mock_dir("api/path/apis/get_services", {
   test_that("get_services() returns expected result", {
     beekeeper::skip_if_not_exported("get_services")
     expect_snapshot({

--- a/tests/testthat/_fixtures/guru/testthat/test-paths-apis-list_apis.R
+++ b/tests/testthat/_fixtures/guru/testthat/test-paths-apis-list_apis.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/apis/list_apis", {
+httptest2::with_mock_dir("api/path/apis/list_apis", {
   test_that("list_apis() returns expected result", {
     beekeeper::skip_if_not_exported("list_apis")
     expect_snapshot({

--- a/tests/testthat/_fixtures/trello/testthat/test-paths-board-add_boards.R
+++ b/tests/testthat/_fixtures/trello/testthat/test-paths-board-add_boards.R
@@ -3,7 +3,7 @@
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/board/add_boards", {
+httptest2::with_mock_dir("api/path/board/add_boards", {
   test_that("add_boards() returns expected result", {
     beekeeper::skip_if_not_exported("add_boards")
     expect_snapshot({

--- a/vignettes/beekeeper.Rmd
+++ b/vignettes/beekeeper.Rmd
@@ -523,7 +523,7 @@ For example, this is the generated `tests/testthat/test-paths-audit-get_audit_ca
 # arguments for the tests to succeed. We recommend expanding these tests to
 # check for specific expectations, rather than simply using a snapshot.
 
-with_mock_dir("api/path/audit/fec_get_audit_case", {
+httptest2::with_mock_dir("api/path/audit/fec_get_audit_case", {
   test_that("fec_get_audit_case() returns expected result", {
     expect_snapshot({
       test_result <- fec_get_audit_case(


### PR DESCRIPTION
IDEs were complaining that `with_mock_dir` wasn't available (even though it is when tests run), so I added an explicit namespace.